### PR TITLE
Adding support for Raspberry Pi OS

### DIFF
--- a/raspberry_pi_os/Dockerfile
+++ b/raspberry_pi_os/Dockerfile
@@ -1,0 +1,35 @@
+# inspired by https://github.com/wozhub/docker-alacritty
+
+FROM debian:latest as BUILDER
+
+ENV ALACRITTY_VERSION 0.5.0
+ENV ALACRITTY_URL https://github.com/alacritty/alacritty/archive/v${ALACRITTY_VERSION}.zip
+
+RUN apt-get update && \
+    apt-get -y install \
+        cmake \
+        pkg-config \
+        libfreetype6-dev \
+        libfontconfig1-dev \
+        libxcb-xfixes0-dev \
+        python3 \
+	curl \
+        unzip
+
+RUN curl -o /tmp/rustup.sh https://sh.rustup.rs && \
+    sh /tmp/rustup.sh -y && \
+    export PATH="$HOME/.cargo/bin:${PATH}" && \
+    rustup override set stable && \
+    rustup update stable
+    
+RUN echo "Downloading ${ALACRITTY_URL}" && \
+    curl -o /tmp/alacritty.zip -L "${ALACRITTY_URL}" && \
+    cd /tmp && \
+    unzip /tmp/alacritty.zip && \
+    cd "/tmp/alacritty-${ALACRITTY_VERSION}" && \
+    . $HOME/.cargo/env && cargo build --release && \
+    cp target/release/alacritty /
+
+FROM alpine 
+
+COPY --from=BUILDER /alacritty /alacritty

--- a/raspberry_pi_os/build_and_install_alacritty.sh
+++ b/raspberry_pi_os/build_and_install_alacritty.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script uses a docker container to build alacritty from sources,
+# saves the built binary to a small Alpine container, copies the binary
+# to /usr/local/bin, and removes the saved Docker image.  
+#
+# Why is this helpful?  Alacritty is not packaged for Raspberry Pi OS! 
+# And this build process doesn't require the installation of build-
+# related packages on your Raspberry Pi.
+
+set -eo pipefail
+
+if [ "$USER" != "root" ]; then
+  echo "ERROR:  You must run $0 as user root."
+  exit 1
+fi
+
+if ! which docker >/dev/null 2>&1; then
+  echo "Cannot locate 'docker' in user root's path."
+  exit 1
+fi
+
+docker build -t alacritty-alpine .
+docker stop alacritty 2>/dev/null || true
+docker run -d --rm --name alacritty alacritty-alpine sh -c 'while true; do sleep 2; date; done'
+docker cp alacritty:/alacritty /usr/local/bin/
+docker stop alacritty
+docker rmi alacritty-alpine
+
+echo -e "\n\nAlacritty installed to /usr/local/bin/alacritty."


### PR DESCRIPTION
Alacritty is not packaged for Raspberry Pi OS.  If your Raspberry Pi has Docker, this method of getting Alacritty on your Pi is much cleaner than installing the various build tools and then building and installing.